### PR TITLE
set log4j2.xml as javaOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ You must define the `log4j.configurationFile` explicitly when the JVM is loaded 
 ```bash
 sbt -Dlog4j.configurationFile=conf/log4j2.xml
 ```
-
+Or you can set as javaOptions in `build.sbt`:
+```bash
+javaOptions += "-Dlog4j.configurationFile=conf/log4j2.xml"
+```
 If you do not run with `log4j.configurationFile` loaded, you will see this error:
 
 ```log

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 name := """play-2.6-log4j2"""
 
 version := "1.0-SNAPSHOT"
@@ -21,3 +22,5 @@ scalaVersion in ThisBuild := "2.12.4"
 crossScalaVersions := Seq("2.11.12", "2.12.4")
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
+
+javaOptions += "-Dlog4j.configurationFile=conf/log4j2.xml"


### PR DESCRIPTION
Personally, It is more elegant to set log4j2.xml as javaOptions.